### PR TITLE
Add bilingual portfolio download section to Por qué Nosotros page

### DIFF
--- a/docs/portafolio-servicios-es.pdf
+++ b/docs/portafolio-servicios-es.pdf
@@ -1,0 +1,80 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20251016164057+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20251016164057+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (Portafolio de Servicios) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 447
+>>
+stream
+Garo=9i$C,&;KZP'm!>aYR?[RhR(hO`'Y1up+fnXZ3GK@?"h_pmm'/gerZ![m,j`16c!"kebsUon<h)KZN:k.RY-KM(t)K18nZsBKJ7-'OUAsFY'S#AKOcCt/%F<=X"iec0Ot<)jGl\Kp=GD?6[J@AP<Eop-OEh?H1?a#+g7BK,LF%NM(/_Z>THWN$7kgH2]h`Z%V:PE&"5*F@4N1!;rOsF$W3\(1`9oA<(qD]oXU@b-jEt.O;WOUC\B%T=Wi2,`8r)Jpf&7pqBra@mrQ_teXES!c.AmKj8/k#[8Y6pC`Rf,Eb3rMChr6#N-QCAL6p:@ae97i\QuRE?nd01Wl]>8o_F=[dRJib_@/ST8nag.oE:pQ9[+7!RTs]MU\b+1-1f?fnm1!>M+81LcE>#_#@-8[h;D`DgL/;)Zdrj8SH(_ckc&5hAL%FC:E!j&H&L)=~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000651 00000 n 
+0000000719 00000 n 
+0000001030 00000 n 
+0000001089 00000 n 
+trailer
+<<
+/ID 
+[<8461a8c54eda85f2deb9e27736dfe8d5><8461a8c54eda85f2deb9e27736dfe8d5>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 10
+>>
+startxref
+1626
+%%EOF

--- a/docs/service-portfolio-en.pdf
+++ b/docs/service-portfolio-en.pdf
@@ -1,0 +1,80 @@
+%PDF-1.3
+% ReportLab Generated PDF document http://www.reportlab.com
+1 0 obj
+<<
+/F1 2 0 R /F2 3 0 R /F3 4 0 R
+>>
+endobj
+2 0 obj
+<<
+/BaseFont /Helvetica /Encoding /WinAnsiEncoding /Name /F1 /Subtype /Type1 /Type /Font
+>>
+endobj
+3 0 obj
+<<
+/BaseFont /Helvetica-Bold /Encoding /WinAnsiEncoding /Name /F2 /Subtype /Type1 /Type /Font
+>>
+endobj
+4 0 obj
+<<
+/BaseFont /Helvetica-Oblique /Encoding /WinAnsiEncoding /Name /F3 /Subtype /Type1 /Type /Font
+>>
+endobj
+5 0 obj
+<<
+/Contents 9 0 R /MediaBox [ 0 0 612 792 ] /Parent 8 0 R /Resources <<
+/Font 1 0 R /ProcSet [ /PDF /Text /ImageB /ImageC /ImageI ]
+>> /Rotate 0 /Trans <<
+
+>> 
+  /Type /Page
+>>
+endobj
+6 0 obj
+<<
+/PageMode /UseNone /Pages 8 0 R /Type /Catalog
+>>
+endobj
+7 0 obj
+<<
+/Author (anonymous) /CreationDate (D:20251016164057+00'00') /Creator (ReportLab PDF Library - www.reportlab.com) /Keywords () /ModDate (D:20251016164057+00'00') /Producer (ReportLab PDF Library - www.reportlab.com) 
+  /Subject (unspecified) /Title (Service Portfolio) /Trapped /False
+>>
+endobj
+8 0 obj
+<<
+/Count 1 /Kids [ 5 0 R ] /Type /Pages
+>>
+endobj
+9 0 obj
+<<
+/Filter [ /ASCII85Decode /FlateDecode ] /Length 462
+>>
+stream
+Garo=:N+]I&B4,:'^o-810ltkWnp>e,U<kbn1g9GSg8qH4(`]-1jjVhFp_4tZ=M'qB7KO0ZbqbcDL=Bii)>VrT,h0nH36)VAuNIR<F:`3M/k?7Pq1"l\iV.&,o3sJ^W6"+NX'88:E&go^$%Q-5>],p6a@0-EPnN\I@E'_8?:q!CLlf(La+/;?"Zj$[#`Ro,A#8aE0S"fKZmY!\Acdc]]9aSA0_nV#-'U,^,Bpd)0jY@n4G:r5iV%?BA8&=fQp-$J$>6^NS*M\%F*50*n8C<Bb`4t9F\CUpB%s5]B'Z$OV7s]P'+12K$E92F%V+b?."<Y;dts,p9?J!a)s83;fMiEdV/Ol""1):m=#nTV2cM"Z@5YD#q%Qo$uA:cER0g@K(Qi5b=3D=!$A;%<X/G5(QG<p)e>^`:Eu]5lV->3M@8&]ANc(`8[FE]_AHtUakL.q@P-g0VK)8J&7s&V~>endstream
+endobj
+xref
+0 10
+0000000000 65535 f 
+0000000073 00000 n 
+0000000124 00000 n 
+0000000231 00000 n 
+0000000343 00000 n 
+0000000458 00000 n 
+0000000651 00000 n 
+0000000719 00000 n 
+0000001024 00000 n 
+0000001083 00000 n 
+trailer
+<<
+/ID 
+[<b28dbaaa2c2b9a600959ad2ae4d1700d><b28dbaaa2c2b9a600959ad2ae4d1700d>]
+% ReportLab generated PDF document -- digest (http://www.reportlab.com)
+
+/Info 7 0 R
+/Root 6 0 R
+/Size 10
+>>
+startxref
+1635
+%%EOF

--- a/porque-nosotros.html
+++ b/porque-nosotros.html
@@ -363,6 +363,61 @@
             filter: grayscale(0%);
             opacity: 1;
         }
+
+        .portfolio-download-section {
+            background: radial-gradient(circle at top right, rgba(108, 99, 255, 0.12), transparent 55%), var(--white-color);
+        }
+        .portfolio-download-section .section-intro {
+            max-width: 760px;
+        }
+        .download-grid {
+            display: grid;
+            grid-template-columns: repeat(auto-fit, minmax(280px, 1fr));
+            gap: 30px;
+            margin-top: 40px;
+        }
+        .download-card {
+            background: var(--white-color);
+            border-radius: var(--border-radius);
+            padding: 35px 30px;
+            box-shadow: 0 18px 40px rgba(0, 0, 0, 0.06);
+            position: relative;
+            overflow: hidden;
+        }
+        .download-card::before {
+            content: '';
+            position: absolute;
+            inset: -60% 50% auto -30%;
+            height: 220px;
+            background: linear-gradient(135deg, rgba(0, 167, 134, 0.15), rgba(108, 99, 255, 0.15));
+            transform: rotate(12deg);
+            z-index: 0;
+        }
+        .download-card h3 {
+            font-size: 1.5em;
+            margin-bottom: 12px;
+            position: relative;
+            z-index: 1;
+        }
+        .download-card p {
+            margin-bottom: 22px;
+            position: relative;
+            z-index: 1;
+        }
+        .download-card .btn {
+            position: relative;
+            z-index: 1;
+            width: 100%;
+            text-align: center;
+        }
+        .download-card .btn.btn-outline {
+            border-color: var(--secondary-accent-color);
+            color: var(--secondary-accent-color);
+        }
+        .download-card .btn.btn-outline:hover {
+            background: var(--secondary-accent-color);
+            color: var(--white-color);
+        }
         .client-placeholder {
             font-weight: 700;
             text-transform: uppercase;
@@ -794,6 +849,25 @@
     
 
                     </a>
+                </div>
+            </div>
+        </section>
+
+        <section class="page-section portfolio-download-section" id="portafolio-descargas">
+            <div class="container">
+                <h2 class="fade-in-element">Descarga nuestro portafolio de servicios</h2>
+                <p class="section-intro fade-in-element" style="transition-delay: 0.1s;">Explora la información completa de nuestras soluciones en representación GP-12, contención de calidad, re-trabajos y más. Descarga el portafolio en tu idioma preferido y compártelo con tu equipo.</p>
+                <div class="download-grid">
+                    <div class="download-card fade-in-element" style="transition-delay: 0.15s;">
+                        <h3>Versión en español</h3>
+                        <p>Incluye la descripción detallada de nuestros servicios, indicadores de desempeño y casos de éxito locales.</p>
+                        <a class="btn" href="docs/portafolio-servicios-es.pdf" download>Descargar portafolio (ES)</a>
+                    </div>
+                    <div class="download-card fade-in-element" style="transition-delay: 0.25s;">
+                        <h3>English version</h3>
+                        <p>Get the complete overview of our capabilities, quality metrics and partnership models in English.</p>
+                        <a class="btn btn-outline" href="docs/service-portfolio-en.pdf" download>Download portfolio (EN)</a>
+                    </div>
                 </div>
             </div>
         </section>


### PR DESCRIPTION
## Summary
- add styled download section below the client logos on the "¿Por qué nosotros?" page
- provide direct download links for the Spanish and English service portfolios hosted in the project

## Testing
- not run (static site changes)


------
https://chatgpt.com/codex/tasks/task_e_68f11f823c6c83259436f8681c976d9e